### PR TITLE
👌 IMPROVE: Automatically add router groups to parent router

### DIFF
--- a/router.go
+++ b/router.go
@@ -220,20 +220,21 @@ func (r *Router) Handle(method, path string, handle fasthttp.RequestHandler) {
 	if r.beginPath != "/" {
 		path = r.beginPath + path
 	}
-	var route *Router
+
+	// Call to the parent recursively until main router to register paths in it
 	if r.parent != nil {
-		route = r.parent
-	} else {
-		route = r
-	}
-	if route.trees == nil {
-		route.trees = make(map[string]*node)
+		r.parent.Handle(method, path, handle)
+		return
 	}
 
-	root := route.trees[method]
+	if r.trees == nil {
+		r.trees = make(map[string]*node)
+	}
+
+	root := r.trees[method]
 	if root == nil {
 		root = new(node)
-		route.trees[method] = root
+		r.trees[method] = root
 	}
 
 	root.addRoute(path, handle)

--- a/router.go
+++ b/router.go
@@ -158,13 +158,15 @@ func New() *Router {
 // Group returns a new grouped Router.
 // Path auto-correction, including trailing slashes, is enabled by default.
 func (r *Router) Group(path string) *Router {
-	return &Router{
+	g := &Router{
 		beginPath:              path,
 		RedirectTrailingSlash:  true,
 		RedirectFixedPath:      true,
 		HandleMethodNotAllowed: true,
 		HandleOPTIONS:          true,
 	}
+	r.NotFound = g.Handler
+	return g
 }
 
 // GET is a shortcut for router.Handle("GET", path, handle)

--- a/router_test.go
+++ b/router_test.go
@@ -312,7 +312,6 @@ func TestRouterChaining(t *testing.T) {
 func TestRouterGroup(t *testing.T) {
 	r1 := New()
 	r2 := r1.Group("/boo")
-	r1.NotFound = r2.Handler
 	fooHit := false
 	r1.POST("/foo", func(ctx *fasthttp.RequestCtx) {
 		fooHit = true

--- a/router_test.go
+++ b/router_test.go
@@ -371,7 +371,7 @@ func TestRouterGroup(t *testing.T) {
 		t.Errorf("Regular routing failed with router chaining.")
 		t.FailNow()
 	}
-
+	// testing router group - r2 (grouped from r1)
 	rw.r.WriteString("POST /boo/bar HTTP/1.1\r\n\r\n")
 	go func() {
 		ch <- s.ServeConn(rw)
@@ -391,7 +391,7 @@ func TestRouterGroup(t *testing.T) {
 		t.Errorf("Chained routing failed with router grouping.")
 		t.FailNow()
 	}
-
+	// testing multiple router group - r3 (grouped from r1)
 	rw.r.WriteString("POST /goo/bar HTTP/1.1\r\n\r\n")
 	go func() {
 		ch <- s.ServeConn(rw)
@@ -411,7 +411,7 @@ func TestRouterGroup(t *testing.T) {
 		t.Errorf("Chained routing failed with router grouping.")
 		t.FailNow()
 	}
-
+	// testing multiple router group - r4 (grouped from r1)
 	rw.r.WriteString("POST /moo/bar HTTP/1.1\r\n\r\n")
 	go func() {
 		ch <- s.ServeConn(rw)
@@ -431,7 +431,7 @@ func TestRouterGroup(t *testing.T) {
 		t.Errorf("Chained routing failed with router grouping.")
 		t.FailNow()
 	}
-
+	// testing sub-router group - r5 (grouped from r4)
 	rw.r.WriteString("POST /moo/foo/bar HTTP/1.1\r\n\r\n")
 	go func() {
 		ch <- s.ServeConn(rw)
@@ -451,6 +451,7 @@ func TestRouterGroup(t *testing.T) {
 		t.Errorf("Chained routing failed with subrouter grouping.")
 		t.FailNow()
 	}
+	// testing multiple sub-router group - r6 (grouped from r5)
 	rw.r.WriteString("POST /moo/foo/foo/bar HTTP/1.1\r\n\r\n")
 	go func() {
 		ch <- s.ServeConn(rw)


### PR DESCRIPTION
At #9 I added router grouping feature. But it was still required to chain the group with it's parent router using `r.NotFound = group.Handler`.

I think we should combine the group with it's parent automatically. So now someone can try group as:

```
r := router.New()
api := r.Group("/api")
api.GET("/bar",bar)
```

And the `api` will automatically get chained with `r`