### PR TITLE
Bugfix

### DIFF
--- a/radix/node.go
+++ b/radix/node.go
@@ -427,7 +427,11 @@ func (n *node) find(path string, buf *bytebufferpool.ByteBuffer) (bool, bool) {
 			return true, true
 		}
 
-		return n.handler != nil, false
+		if n.handler != nil {
+			return true, false
+		} else {
+			bufferRemoveString(buf, n.path)
+		}
 	}
 
 	return false, false
@@ -467,7 +471,9 @@ func (n *node) findFromChild(path string, buf *bytebufferpool.ByteBuffer) (bool,
 					return true, true
 				}
 
-				return child.handler != nil, false
+				if child.handler != nil {
+					return true, false
+				}
 			}
 
 			bufferRemoveString(buf, path[:end])

--- a/radix/tree.go
+++ b/radix/tree.go
@@ -79,7 +79,9 @@ func (t *Tree) Get(path string, ctx *fasthttp.RequestCtx) (fasthttp.RequestHandl
 		handler, tsr := t.root.getFromChild(path, ctx)
 		if handler == nil {
 			if t.root.wildcard != nil {
-				ctx.SetUserValue(t.root.wildcard.paramKey, path)
+				if ctx != nil {
+					ctx.SetUserValue(t.root.wildcard.paramKey, path)
+				}
 				return t.root.wildcard.handler, false
 			}
 		}

--- a/radix/tree.go
+++ b/radix/tree.go
@@ -74,7 +74,17 @@ func (t *Tree) Get(path string, ctx *fasthttp.RequestCtx) (fasthttp.RequestHandl
 			return nil, false
 		}
 
-		return t.root.getFromChild(path, ctx)
+		path = path[len(t.root.path):]
+
+		handler, tsr := t.root.getFromChild(path, ctx)
+		if handler == nil {
+			if t.root.wildcard != nil {
+				ctx.SetUserValue(t.root.wildcard.paramKey, path)
+				return t.root.wildcard.handler, false
+			}
+		}
+
+		return handler, tsr
 
 	} else if path == t.root.path {
 		switch {

--- a/radix/tree.go
+++ b/radix/tree.go
@@ -74,8 +74,6 @@ func (t *Tree) Get(path string, ctx *fasthttp.RequestCtx) (fasthttp.RequestHandl
 			return nil, false
 		}
 
-		path = path[len(t.root.path):]
-
 		return t.root.getFromChild(path, ctx)
 
 	} else if path == t.root.path {

--- a/radix/tree_test.go
+++ b/radix/tree_test.go
@@ -240,6 +240,11 @@ func Test_TreeRootWildcard(t *testing.T) {
 	testHandlerAndParams(t, tree, "/", handler, false, map[string]interface{}{
 		"filepath": "",
 	})
+
+	tree.Add("/hello/{a}/{b}/{c}", handler)
+	testHandlerAndParams(t, tree, "/hello/a", handler, false, map[string]interface{}{
+		"filepath": "hello/a",
+	})
 }
 
 func Test_TreeNilHandler(t *testing.T) {


### PR DESCRIPTION
```go
package main

import (
        "log"

        "github.com/fasthttp/router"
        "github.com/valyala/fasthttp"
)

func hello(ctx *fasthttp.RequestCtx) {
        // todo
}

func main() {
        r := router.New()
        r.GET("/hello/{a}/{b}/{c}", hello)
        r.ServeFiles("/{filepath:*}", "static")

        log.Fatal(fasthttp.ListenAndServe(":18080", r.Handler))
}
```

```bash
$ curl -v http://localhost:18080/hello/a
* About to connect() to localhost port 18080 (#0)
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 18080 (#0)
> GET /hello/a HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:18080
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Server: fasthttp
< Date: Thu, 18 Mar 2021 09:00:12 GMT
< Content-Length: 0
< Location: http://localhost:18080/hhello/a
< 
* Connection #0 to host localhost left intact
```

The location url is error.