### PR TITLE
Fix user params for regex paths

### DIFF
--- a/radix/node.go
+++ b/radix/node.go
@@ -95,7 +95,7 @@ func (n *node) findEndIndexAndValues(path string) (int, []string) {
 			continue
 		}
 
-		values[i] = path[index[j-1]:index[j]]
+		values[i] = copyString(path[index[j-1]:index[j]])
 
 		i++
 	}


### PR DESCRIPTION
Fixes #38 once again. 
See my comment https://github.com/fasthttp/router/issues/38#issuecomment-870527963