### PR TITLE
Add support for setting middlewares for groups and fileserv

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,55 +1,85 @@
 package router
 
-import "github.com/valyala/fasthttp"
+import (
+	"github.com/valyala/fasthttp"
+)
 
 // Group returns a new group.
 // Path auto-correction, including trailing slashes, is enabled by default.
-func (g *Group) Group(path string) *Group {
-	return g.router.Group(g.prefix + path)
+// Currently only one group middleware can be provided.
+func (g *Group) Group(path string, middleware ...RequestHandlerFunc) *Group {
+	return g.router.Group(g.prefix+path, middleware...)
 }
 
 // GET is a shortcut for group.Handle(fasthttp.MethodGet, path, handler)
 func (g *Group) GET(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.GET(g.prefix+path, handler)
 }
 
 // HEAD is a shortcut for group.Handle(fasthttp.MethodHead, path, handler)
 func (g *Group) HEAD(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.HEAD(g.prefix+path, handler)
 }
 
 // POST is a shortcut for group.Handle(fasthttp.MethodPost, path, handler)
 func (g *Group) POST(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.POST(g.prefix+path, handler)
 }
 
 // PUT is a shortcut for group.Handle(fasthttp.MethodPut, path, handler)
 func (g *Group) PUT(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.PUT(g.prefix+path, handler)
 }
 
 // PATCH is a shortcut for group.Handle(fasthttp.MethodPatch, path, handler)
 func (g *Group) PATCH(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.PATCH(g.prefix+path, handler)
 }
 
 // DELETE is a shortcut for group.Handle(fasthttp.MethodDelete, path, handler)
 func (g *Group) DELETE(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.DELETE(g.prefix+path, handler)
 }
 
 // OPTIONS is a shortcut for group.Handle(fasthttp.MethodOptions, path, handler)
 func (g *Group) CONNECT(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.CONNECT(g.prefix+path, handler)
 }
 
 // OPTIONS is a shortcut for group.Handle(fasthttp.MethodOptions, path, handler)
 func (g *Group) OPTIONS(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.OPTIONS(g.prefix+path, handler)
 }
 
 // OPTIONS is a shortcut for group.Handle(fasthttp.MethodOptions, path, handler)
 func (g *Group) TRACE(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.TRACE(g.prefix+path, handler)
 }
 
@@ -57,32 +87,37 @@ func (g *Group) TRACE(path string, handler fasthttp.RequestHandler) {
 //
 // WARNING: Use only for routes where the request method is not important
 func (g *Group) ANY(path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.ANY(g.prefix+path, handler)
 }
 
 // ServeFiles serves files from the given file system root.
 // The path must end with "/{filepath:*}", files are then served from the local
 // path /defined/root/dir/{filepath:*}.
+// Currently only one group middleware can be provided.
 // For example if root is "/etc" and {filepath:*} is "passwd", the local file
 // "/etc/passwd" would be served.
 // Internally a fasthttp.FSHandler is used, therefore http.NotFound is used instead
 // Use:
 //     router.ServeFiles("/src/{filepath:*}", "./")
-func (g *Group) ServeFiles(path string, rootPath string) {
-	g.router.ServeFiles(g.prefix+path, rootPath)
+func (g *Group) ServeFiles(path string, rootPath string, middleware ...RequestHandlerFunc) {
+	g.router.ServeFiles(g.prefix+path, rootPath, middleware...)
 }
 
 // ServeFilesCustom serves files from the given file system settings.
 // The path must end with "/{filepath:*}", files are then served from the local
 // path /defined/root/dir/{filepath:*}.
+// Currently only one group middleware can be provided.
 // For example if root is "/etc" and {filepath:*} is "passwd", the local file
 // "/etc/passwd" would be served.
 // Internally a fasthttp.FSHandler is used, therefore http.NotFound is used instead
 // of the Router's NotFound handler.
 // Use:
 //     router.ServeFilesCustom("/src/{filepath:*}", *customFS)
-func (g *Group) ServeFilesCustom(path string, fs *fasthttp.FS) {
-	g.router.ServeFilesCustom(g.prefix+path, fs)
+func (g *Group) ServeFilesCustom(path string, fs *fasthttp.FS, middleware ...RequestHandlerFunc) {
+	g.router.ServeFilesCustom(g.prefix+path, fs, middleware...)
 }
 
 // Handle registers a new request handler with the given path and method.
@@ -94,5 +129,8 @@ func (g *Group) ServeFilesCustom(path string, fs *fasthttp.FS) {
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
 func (g *Group) Handle(method, path string, handler fasthttp.RequestHandler) {
+	if g.handler != nil {
+		handler = g.handler(handler)
+	}
 	g.router.Handle(method, g.prefix+path, handler)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -134,3 +134,36 @@ func TestGroup_shortcutsAndHandle(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupMiddleware(t *testing.T) {
+	r := New()
+
+	middlewareCalled := false
+	methodCalled := false
+
+	g := r.Group("/v1", func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			middlewareCalled = true
+			next(ctx)
+		}
+	})
+
+	g.GET("/test", func(ctx *fasthttp.RequestCtx) {
+		methodCalled = true
+	})
+
+	handle, _ := r.Lookup(fasthttp.MethodGet, "/v1/test", nil)
+	if handle == nil {
+		t.Error("Bad shorcurt")
+		return
+	}
+
+	handle(nil)
+
+	if !middlewareCalled {
+		t.Error("Middleware was not called")
+	}
+	if !methodCalled {
+		t.Error("Method was not called")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -77,8 +77,12 @@ type Router struct {
 	globalAllowed string
 }
 
+// RequestHandlerFunc is an adapter to allow to use it as wrapper for fasthttp.RequestHandler
+type RequestHandlerFunc func(h fasthttp.RequestHandler) fasthttp.RequestHandler
+
 // Group is a sub-router to group paths
 type Group struct {
-	router *Router
-	prefix string
+	router  *Router
+	handler RequestHandlerFunc
+	prefix  string
 }


### PR DESCRIPTION
Currently only single middleware per-group can be provided and not to break compatibility and be more future proof function argument was introduced to `Group` as params that allows to specify only optionally without introducing new function.

Fixes #56